### PR TITLE
Fix tool message parsing

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -109,6 +109,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         return SystemMessage(content=_dict["content"])
     elif role == "function":
         return FunctionMessage(content=_dict["content"], name=_dict["name"])
+    elif role == "tool":
+        return ToolMessage(content=_dict["content"], tool_call_id=_dict["tool_call_id"])
     else:
         return ChatMessage(content=_dict["content"], role=role)
 
@@ -136,9 +138,9 @@ def _convert_delta_to_message_chunk(
     content = delta.content or ""
     if delta.function_call:
         additional_kwargs = {"function_call": dict(delta.function_call)}
-    # The hasattr check is necessary because litellm explicitly deletes the 
-    # `reasoning_content` attribute when it is absent to comply with the OpenAI API. 
-    # This ensures that the code gracefully handles cases where the attribute is 
+    # The hasattr check is necessary because litellm explicitly deletes the
+    # `reasoning_content` attribute when it is absent to comply with the OpenAI API.
+    # This ensures that the code gracefully handles cases where the attribute is
     # missing, avoiding potential errors or non-compliance with the API.
     elif hasattr(delta, "reasoning_content") and delta.reasoning_content:
         additional_kwargs = {"reasoning_content": delta.reasoning_content}

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -86,3 +86,15 @@ class TestChatLiteLLMUnit(ChatModelUnitTests):
         assert tool_call_chunk["name"] == mock_tool_call_name
         assert tool_call_chunk["args"] == mock_tool_call_arguments
         assert tool_call_chunk["index"] == mock_tool_call_index
+
+    def test_convert_dict_to_tool_message(self):
+        """Ensure tool role dicts convert to ToolMessage."""
+        from langchain_litellm.chat_models.litellm import _convert_dict_to_message
+
+        mock_dict = {"role": "tool", "content": "result", "tool_call_id": "123"}
+        message = _convert_dict_to_message(mock_dict)
+        from langchain_core.messages import ToolMessage
+
+        assert isinstance(message, ToolMessage)
+        assert message.content == "result"
+        assert message.tool_call_id == "123"


### PR DESCRIPTION
## Summary
- handle `tool` role in `_convert_dict_to_message`
- add unit test covering tool role

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847cc0876f88328be19b49fbde20fda