### PR TITLE
Fix: Preserve litellm_params in ChatLiteLLMRouter

### DIFF
--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -95,6 +95,7 @@ class ChatLiteLLMRouter(ChatLiteLLM):
 
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
+        params = {k:v for k, v in params.items() if v is not None}
         self._prepare_params_for_router(params)
 
         response = self.router.completion(
@@ -113,6 +114,7 @@ class ChatLiteLLMRouter(ChatLiteLLM):
         default_chunk_class = AIMessageChunk
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
+        params = {k:v for k, v in params.items() if v is not None}
         params["stream_options"] = self.stream_options
         self._prepare_params_for_router(params)
 
@@ -142,6 +144,7 @@ class ChatLiteLLMRouter(ChatLiteLLM):
         default_chunk_class = AIMessageChunk
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
+        params = {k:v for k, v in params.items() if v is not None}
         params["stream_options"] = self.stream_options
         self._prepare_params_for_router(params)
 
@@ -182,6 +185,7 @@ class ChatLiteLLMRouter(ChatLiteLLM):
 
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
+        params = {k:v for k, v in params.items() if v is not None}
         self._prepare_params_for_router(params)
 
         response = await self.router.acompletion(


### PR DESCRIPTION
**Description**
This PR fixes a bug in ChatLiteLLMRouter where the litellm_params for individual models were being incorrectly overwritten by the default values of the parent ChatLiteLLM class.

**Problem**
If a model was configured with its own specific litellm_params, the router's instantiation logic would overwrite this with the parent class's default, preventing custom per-model configuration.

**Solution**
The changes ensure that the model's explicitly set litellm_params are respected and prioritized over the None values during router setup. This allows users to correctly pass unique parameters to different models managed by the router.

Type of change
[x] Bug fix