### PR TITLE
Add logprobs to ChatResult for ChatLiteLLM

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -429,7 +429,7 @@ class ChatLiteLLM(BaseChatModel):
                 message.usage_metadata = _create_usage_metadata(token_usage)
             gen = ChatGeneration(
                 message=message,
-                generation_info=dict(finish_reason=res.get("finish_reason")),
+                generation_info=dict(finish_reason=res.get("finish_reason"), logprobs=res.get("logprobs")),
             )
             generations.append(gen)
         set_model_value = self.model


### PR DESCRIPTION
When requesting logprobs using ChatLiteLLM the results aren't returned as part of the ChatResponse.response_metadata. This MR adds it in

You can reproduce the problem with this python script using [fireworks.ai](https://fireworks.ai/) (or any provider that supplies logprobs)
```python
    chat = ChatLiteLLM(
        model="fireworks_ai/accounts/fireworks/models/deepseek-v3p1",
        temperature=0.3,
        # Pass logprobs and top_logprobs through model_kwargs
        model_kwargs={
            "logprobs": 1,
        }
    )
    messages = [
        SystemMessage(content="You are a helpful assistant."),
        HumanMessage(content="What is the capital of France?")
    ]
    response = chat.invoke(messages)
    print(response.response_metadata["logprobs"])
```