### PR TITLE
Add support for num_ctx parameter and improve documentation

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -302,6 +302,9 @@ class ChatLiteLLM(BaseChatModel):
     """Number of chat completions to generate for each prompt. Note that the API may
        not return the full n completions if duplicates are generated."""
     max_tokens: Optional[int] = None
+    """The maximum number of tokens to generate in the reply."""
+    num_ctx: Optional[int] = None
+    """Context window size (e.g. for Ollama models)."""
 
     max_retries: int = 1
 
@@ -319,6 +322,7 @@ class ChatLiteLLM(BaseChatModel):
             "n": self.n,
             "temperature": self.temperature,
             "custom_llm_provider": self.custom_llm_provider,
+            "num_ctx": self.num_ctx,
             **self.model_kwargs,
         }
 
@@ -778,6 +782,7 @@ class ChatLiteLLM(BaseChatModel):
             "top_p": self.top_p,
             "top_k": self.top_k,
             "n": self.n,
+            "num_ctx": self.num_ctx,
         }
 
     @property


### PR DESCRIPTION
- Added `num_ctx` field to `ChatLiteLLM` to allow setting the context window size, particularly for Ollama models.
- Updated `_default_params` and `_identifying_params` to ensure `num_ctx` is correctly propagated to the LiteLLM client and identifying metadata.
- Added descriptive docstrings for both `num_ctx` and `max_tokens` to improve code clarity and consistency.

Fixes #27