### PR TITLE
Fix request_timeout parameter not being respected

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -316,7 +316,7 @@ class ChatLiteLLM(BaseChatModel):
             set_model_value = self.model_name
         return {
             "model": set_model_value,
-            "force_timeout": self.request_timeout,
+            "timeout": self.request_timeout,
             "max_tokens": self.max_tokens,
             "stream": self.streaming,
             "n": self.n,
@@ -351,7 +351,7 @@ class ChatLiteLLM(BaseChatModel):
         self.client.organization = self.organization
         creds: Dict[str, Any] = {
             "model": set_model_value,
-            "force_timeout": self.request_timeout,
+            "timeout": self.request_timeout,
             "api_base": self.api_base,
         }
         # Forward any extra headers to the client and include in params


### PR DESCRIPTION
- Renamed `force_timeout` to `timeout` in `_default_params` and `_client_params` within `ChatLiteLLM`.
- Previously, `request_timeout` was mapped to `force_timeout`, which caused LiteLLM to ignore the custom timeout value and revert to the default (600s).
- Verified that both `request_timeout` (now passed as `timeout`) and `max_retries` are correctly propagated to the client.

Fixes #28