### PR TITLE
Add support for gemini-2.5-pro by updating litellm dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ disallow_untyped_defs = "True"
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 langchain-core = ">0.3.15,<2.0.0"
-litellm = "^1.65.1"
+litellm = "^1.77.2"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]


### PR DESCRIPTION
- Bump `litellm` version to `^1.77.2` (Verified support added in v1.73.6+).

Fixes #9