### PR TITLE
chore(ci): configure release-please to use standard version tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "python",
       "package-name": "langchain-litellm",
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     }


### PR DESCRIPTION
Add `"include-component-in-tag": false` to the release-please config. This ensures the bot looks for our standard historical `vX.Y.Z` git tags instead of expecting component-prefixed tags (`langchain-litellm-vX.Y.Z`), fixing the issue where it pulls in the entire commit history.