### PR TITLE
chore(ci): configure release-please to bump minor version for features

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "package-name": "langchain-litellm",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
- Set `"bump-patch-for-minor-pre-major": false` in the release-please config.
- This ensures that new features (`feat:`) will correctly trigger a minor version bump (e.g., to 0.6.0) instead of a patch bump during our 0.x release phase, aligning with our current SemVer strategy.