### PR TITLE
fix: exclude compromised litellm versions from deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "langchain-core>0.3.15,<2.0.0",
-    "litellm>=1.77.2,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
+    "litellm>=1.77.2,<2.0.0,!=1.82.7,!=1.82.8",
     "httpx>=0.28.1,<0.29.0",
     "cryptography>=46.0.5,<47.0.0",
 ]
@@ -46,6 +46,7 @@ Reddit = "https://www.reddit.com/r/LangChain/"
 
 [dependency-groups]
 test = [
+    "langchain>=1.0.0,<2.0.0",
     "pytest>=7.4.4,<8.0.0",
     "pytest-asyncio>=0.20.3,<1.0.0",
     "pytest-socket>=0.6.0,<1.0.0",
@@ -64,8 +65,6 @@ test = [
     "pytest-xdist>=3.6.1,<4.0.0",
     "blockbuster>=1.5.18,<1.6",
     "cffi>=2.0.0,<3.0.0; python_version >= '3.10'",
-    "langchain-core>=1.0.0,<2.0.0",
-    "langchain>=1.0.0,<2.0.0",
     "toml>=0.10.2",
 ]
 codespell = [
@@ -79,6 +78,8 @@ dev = [
     "python-dotenv>=1.2.1,<2.0.0",
 ]
 typing = [
+    "langchain>=1.0.0,<2.0.0",
+    "langchain-text-splitters>=0.3.7,<0.4.0",
     "mypy>=1.12,<2.0",
     "types-pyyaml>=6.0.12.2,<7.0.0.0",
     "types-requests>=2.28.11.5,<3.0.0.0",
@@ -87,9 +88,6 @@ typing = [
     "types-chardet>=5.0.4.6,<6.0.0.0",
     "types-redis>=4.3.21.6,<5.0.0.0",
     "mypy-protobuf>=3.0.0,<4.0.0",
-    "langchain-core>=1.0.0,<2.0.0",
-    "langchain-text-splitters>=0.3.7,<0.4.0",
-    "langchain>=1.0.0,<2.0.0",
     "cffi>=2.0.0,<3.0.0",
 ]
 test_integration = []

--- a/uv.lock
+++ b/uv.lock
@@ -1454,7 +1454,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.14"
+version = "1.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1466,9 +1466,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/ff/c5e3da8eca8a18719b300ef6c29e28208ee4e9da7f9749022b96292b6541/langchain_core-1.2.14.tar.gz", hash = "sha256:09549d838a2672781da3a9502f3b9c300863284b77b27e2a6dac4e6e650acfed", size = 833399, upload-time = "2026-02-19T14:22:33.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/e4/135ef5bbb5b97bdf15f777b86d7fba2ef8a162723ae96b3c7c1add9891a9/langchain_core-1.2.21.tar.gz", hash = "sha256:1a121d13976dc0908d5a8222262810ea483a4cf2b05006bdba75df5b11b554b3", size = 841063, upload-time = "2026-03-23T18:01:01.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/41/fe6ae9065b866b1397adbfc98db5e1648e8dcd78126b8e1266fcbe2d6395/langchain_core-1.2.14-py3-none-any.whl", hash = "sha256:b349ca28c057ac1f9b5280ea091bddb057db24d0f1c3c89bbb590713e1715838", size = 501411, upload-time = "2026-02-19T14:22:32.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ae/f7591e57d4c6b64b521f9832fc471070902718c59bf135401f3b90a3f7ef/langchain_core-1.2.21-py3-none-any.whl", hash = "sha256:486cb405e2ecb0c407cb5fb5379ed0f919eb4b8a868b60cc8c3c15a3dfb560a7", size = 505756, upload-time = "2026-03-23T18:01:00.176Z" },
 ]
 
 [[package]]
@@ -1499,7 +1499,6 @@ test = [
     { name = "duckdb-engine" },
     { name = "freezegun" },
     { name = "langchain" },
-    { name = "langchain-core" },
     { name = "langchain-tests" },
     { name = "lark" },
     { name = "pandas" },
@@ -1519,7 +1518,6 @@ test = [
 typing = [
     { name = "cffi" },
     { name = "langchain" },
-    { name = "langchain-core" },
     { name = "langchain-text-splitters" },
     { name = "mypy" },
     { name = "mypy-protobuf" },
@@ -1535,8 +1533,8 @@ typing = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5,<47.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
-    { name = "langchain-core", specifier = ">0.3.15,<2.0.0" },
-    { name = "litellm", specifier = ">=1.77.2,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.2.21,<2.0.0" },
+    { name = "litellm", specifier = ">=1.77.2,!=1.82.7,!=1.82.8,<2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1552,7 +1550,6 @@ test = [
     { name = "duckdb-engine", specifier = ">=0.13.6,<1.0.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-tests", specifier = ">=1.0.0,<2.0.0" },
     { name = "lark", specifier = ">=1.1.5,<2.0.0" },
     { name = "pandas", specifier = ">=2.0.0,<3.0.0" },
@@ -1573,7 +1570,6 @@ test-integration = []
 typing = [
     { name = "cffi", specifier = ">=2.0.0,<3.0.0" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-text-splitters", specifier = ">=0.3.7,<0.4.0" },
     { name = "mypy", specifier = ">=1.12,<2.0" },
     { name = "mypy-protobuf", specifier = ">=3.0.0,<4.0.0" },


### PR DESCRIPTION
Exclude the compromised litellm PyPI versions (v1.82.7, v1.82.8) from the dependency spec to prevent installation of packages containing credential-harvesting malware. Also bumps the `langchain-core` floor to `>=1.2.21` and deduplicates transitive `langchain-core` pins from the `test` and `typing` dependency groups. See [BerriAI/litellm#24518](https://github.com/BerriAI/litellm/issues/24518) for the full incident timeline.

## Changes
- Add `!=1.82.7,!=1.82.8` exclusions to the `litellm` dependency spec in `pyproject.toml`, blocking the two known-compromised versions
- Raise `langchain-core` lower bound from `>0.3.15` to `>=1.2.21` — aligns the runtime floor with the version already resolved in the lockfile
- Remove redundant `langchain-core` entries from the `test` and `typing` dependency groups (already satisfied transitively via `langchain`)