### PR TITLE
fix: bump pyproject.toml to 0.6.4 and harden release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,46 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Update uv.lock when release-please creates/updates a PR
+  # release-please updates pyproject.toml versions but doesn't regenerate lockfiles
+  # https://github.com/googleapis/release-please/issues/2561
+  update-lockfile:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Update lockfile
+        run: uv lock
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          if git diff --staged --quiet; then
+            echo "No lockfile changes to commit"
+          else
+            git commit -m "chore: update uv.lock"
+            git push
+          fi
 
   pypi-publish:
     needs: release-please

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-litellm"
-version = "0.6.3"
+version = "0.6.4"
 
 description = "An integration package connecting LiteLLM and LangChain"
 readme = "README.md"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,10 @@
       "package-name": "langchain-litellm",
       "component": "langchain-litellm",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "extra-files": [
+        "pyproject.toml"
+      ]
     }
   },
   "pull-request-title-pattern": "release(litellm): ${version}",


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version to 0.6.4 (release-please PR #113 failed to do this)
- Add `pyproject.toml` to `extra-files` in release-please config so the `GenericToml` updater handles version bumps (bypasses broken `getPyProject()` codepath that silently fails on larger `pyproject.toml` files)
- Add `update-lockfile` job to regenerate `uv.lock` when release-please creates/updates a PR (mirrors deepagents pattern, ref googleapis/release-please#2561)

### Root cause

PR #120 grew `pyproject.toml` from ~2.3KB to ~5.9KB. release-please's Python strategy wraps `getFileContentsOnBranch()` + `parsePyProject()` in a blanket `try/catch` that returns `null` on any exception, logging "file pyproject.toml did not exist". Every run after #120 skipped the version bump, so the 0.6.4 tag pointed to code with `version = "0.6.3"` → PyPI rejected the upload as duplicate.