### PR TITLE
fix: populate `model_provider` in `response_metadata` and `ls_provider` in `_get_ls_params` (#152)

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -694,7 +694,8 @@ class ChatLiteLLM(BaseChatModel):
             # Set response_metadata on the first chunk only
             if not first_chunk_yielded and isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata = {
-                    "model_name": self.model_name or self.model
+                    "model_name": self.model_name or self.model,
+                    "model_provider": "litellm"
                 }
                 first_chunk_yielded = True
 
@@ -762,7 +763,8 @@ class ChatLiteLLM(BaseChatModel):
             # Set response_metadata on the first chunk only
             if not first_chunk_yielded and isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata = {
-                    "model_name": self.model_name or self.model
+                    "model_name": self.model_name or self.model,
+                    "model_provider": "litellm"
                 }
                 first_chunk_yielded = True
 

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -599,7 +599,8 @@ class ChatLiteLLM(BaseChatModel):
             message = _convert_dict_to_message(res["message"])
             if isinstance(message, AIMessage):
                 message.response_metadata = {
-                    "model_name": self.model_name or self.model
+                    "model_name": self.model_name or self.model,
+                    "model_provider": "litellm",
                 }
                 message.usage_metadata = usage_metadata
             gen = ChatGeneration(

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -1018,7 +1018,27 @@ class ChatLiteLLM(BaseChatModel):
             "n": self.n,
             "num_ctx": self.num_ctx,
         }
+    
+    def _get_ls_params(
+        self,
+        stop: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Return LangSmith tracing parameters for this model.
 
+        Overrides the base implementation to set ``ls_provider`` to ``"litellm"``
+        and ``ls_model_name`` to the resolved model string. These values are used
+        by LangSmith for run tagging and by LangChain middleware such as
+        ``SummarizationMiddleware``, which compares ``response_metadata["model_provider"]``
+        against ``ls_provider`` to decide whether reported token counts should be
+        trusted. Without this override, ``ls_provider`` would be absent and that
+        middleware check would always short-circuit.
+        """
+        params = super()._get_ls_params(stop=stop, **kwargs)
+        params["ls_provider"] = "litellm"
+        params["ls_model_name"] = self.model_name or self.model
+        return params
+    
     @property
     def _llm_type(self) -> str:
         return "litellm-chat"

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -695,7 +695,7 @@ class ChatLiteLLM(BaseChatModel):
             if not first_chunk_yielded and isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata = {
                     "model_name": self.model_name or self.model,
-                    "model_provider": "litellm"
+                    "model_provider": "litellm",
                 }
                 first_chunk_yielded = True
 
@@ -764,7 +764,7 @@ class ChatLiteLLM(BaseChatModel):
             if not first_chunk_yielded and isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata = {
                     "model_name": self.model_name or self.model,
-                    "model_provider": "litellm"
+                    "model_provider": "litellm",
                 }
                 first_chunk_yielded = True
 

--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -155,7 +155,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
             # Set response_metadata on the first chunk only
             if not first_chunk_yielded and isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata = {
-                    "model_name": self.model_name or self.model
+                    "model_name": self.model_name or self.model,
+                    "model_provider": "litellm",
                 }
                 first_chunk_yielded = True
 
@@ -214,7 +215,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
             # Set response_metadata on the first chunk only
             if not first_chunk_yielded and isinstance(chunk, AIMessageChunk):
                 chunk.response_metadata = {
-                    "model_name": self.model_name or self.model
+                    "model_name": self.model_name or self.model,
+                    "model_provider": "litellm",
                 }
                 first_chunk_yielded = True
 
@@ -289,7 +291,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
             message = _convert_dict_to_message(res["message"])
             if isinstance(message, AIMessage):
                 message.response_metadata = {
-                    "model_name": self.model_name or self.model
+                    "model_name": self.model_name or self.model,
+                    "model_provider": "litellm",
                 }
                 message.usage_metadata = usage_metadata
             gen = ChatGeneration(

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -485,3 +485,21 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     assert result["raw"].content == "plain text"
     assert result["parsed"] is None
     assert isinstance(result["parsing_error"], OutputParserException)
+
+def test_response_metadata_contains_model_provider() -> None:
+    """Ensure ChatLiteLLM sets the model_provider in response_metadata."""
+    llm = ChatLiteLLM(model="gpt-4", api_key="fake")
+    
+    mock_response = {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Test response"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    result = llm._create_chat_result(mock_response)
+    
+    assert result.generations[0].message.response_metadata.get("model_provider") == "litellm"

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -486,41 +486,45 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     assert result["parsed"] is None
     assert isinstance(result["parsing_error"], OutputParserException)
 
-def test_aimessage_passes_langchain_summarization_middleware() -> None:
-    """
-    Test that ChatLiteLLM outputs pass LangChain's strict token counting guards.
-    Fixes Issue #152 where missing 'model_provider' caused SummarizationMiddleware to fail.
-    """
+def test_create_chat_result_sets_model_provider() -> None:
+    """Non-streaming path must set model_provider. Fixes #152."""
     llm = ChatLiteLLM(model="gpt-4", api_key="fake")
-    
     mock_response = {
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": "Test response"},
-                "finish_reason": "stop",
-            }
-        ],
+        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
-
     result = llm._create_chat_result(mock_response)
-    last_ai_message = result.generations[0].message
-    
-    # ── Simulate the exact logic from SummarizationMiddleware ──
-    threshold = 10
-    
-    # 1. Must be an AIMessage
-    assert isinstance(last_ai_message, AIMessage)
-    
-    # 2. Must have usage metadata
-    assert last_ai_message.usage_metadata is not None
-    
-    # 3. Must exceed the summarization threshold
-    reported_tokens = last_ai_message.usage_metadata.get("total_tokens", -1)
-    assert reported_tokens >= threshold
-    
-    # 4. CRITICAL FIX: Must have model_provider metadata that matches 'litellm'
-    message_provider = last_ai_message.response_metadata.get("model_provider")
-    assert message_provider == "litellm"
-    
-    # If this test passes, the SummarizationMiddleware returns True instead of False!
+    msg = result.generations[0].message
+    assert isinstance(msg, AIMessage)
+    assert msg.response_metadata.get("model_provider") == "litellm"
+
+
+def test_stream_sets_model_provider_in_response_metadata() -> None:
+    """First streaming chunk must carry model_provider. Fixes #152."""
+    from unittest.mock import patch
+
+    llm = ChatLiteLLM(model="gpt-4", api_key="fake")
+    fake_chunks = [
+        {"choices": [{"delta": {"role": "assistant", "content": "hel"}}], "usage": None},
+        {"choices": [{"delta": {"content": "lo"}}], "usage": None},
+        {"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}},
+    ]
+
+    with patch.object(ChatLiteLLM, "completion_with_retry", return_value=iter(fake_chunks)):
+        chunks = list(llm._stream([]))
+
+    assert chunks[0].message.response_metadata.get("model_provider") == "litellm"
+    assert chunks[1].message.response_metadata == {}
+
+
+def test_get_ls_params_sets_ls_provider() -> None:
+    """ls_provider must match model_provider so SummarizationMiddleware's equality check passes."""
+    llm = ChatLiteLLM(model="gpt-4", api_key="fake")
+    params = llm._get_ls_params()
+    assert params["ls_provider"] == "litellm"
+    assert params["ls_model_name"] == "gpt-4"
+
+    # model_name takes precedence over model when set
+    llm_with_name = ChatLiteLLM(model="gpt-4", model_name="my-deployment", api_key="fake")
+    params = llm_with_name._get_ls_params()
+    assert params["ls_model_name"] == "my-deployment"

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -486,8 +486,11 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     assert result["parsed"] is None
     assert isinstance(result["parsing_error"], OutputParserException)
 
-def test_response_metadata_contains_model_provider() -> None:
-    """Ensure ChatLiteLLM sets the model_provider in response_metadata."""
+def test_aimessage_passes_langchain_summarization_middleware() -> None:
+    """
+    Test that ChatLiteLLM outputs pass LangChain's strict token counting guards.
+    Fixes Issue #152 where missing 'model_provider' caused SummarizationMiddleware to fail.
+    """
     llm = ChatLiteLLM(model="gpt-4", api_key="fake")
     
     mock_response = {
@@ -501,5 +504,23 @@ def test_response_metadata_contains_model_provider() -> None:
     }
 
     result = llm._create_chat_result(mock_response)
+    last_ai_message = result.generations[0].message
     
-    assert result.generations[0].message.response_metadata.get("model_provider") == "litellm"
+    # ── Simulate the exact logic from SummarizationMiddleware ──
+    threshold = 10
+    
+    # 1. Must be an AIMessage
+    assert isinstance(last_ai_message, AIMessage)
+    
+    # 2. Must have usage metadata
+    assert last_ai_message.usage_metadata is not None
+    
+    # 3. Must exceed the summarization threshold
+    reported_tokens = last_ai_message.usage_metadata.get("total_tokens", -1)
+    assert reported_tokens >= threshold
+    
+    # 4. CRITICAL FIX: Must have model_provider metadata that matches 'litellm'
+    message_provider = last_ai_message.response_metadata.get("model_provider")
+    assert message_provider == "litellm"
+    
+    # If this test passes, the SummarizationMiddleware returns True instead of False!

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -72,3 +72,42 @@ def test_router_stream_options_set_for_all_providers():
         else {"include_usage": True}
     )
     assert stream_options == {"include_usage": True}
+
+def test_router_aimessage_passes_langchain_summarization_middleware():
+    """
+    Test that ChatLiteLLMRouter outputs pass LangChain's strict token counting guards.
+    Fixes Issue #152 where missing 'model_provider' caused SummarizationMiddleware to fail.
+    """
+    router = test_router()
+    llm = ChatLiteLLMRouter(router=router)
+
+    mock_response = {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Test response"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    # Router's _create_chat_result requires the metadata kwarg
+    result = llm._create_chat_result(mock_response, metadata={})
+    last_ai_message = result.generations[0].message
+    
+    # ── Simulate the exact logic from SummarizationMiddleware ──
+    threshold = 10
+    
+    # 1. Must be an AIMessage
+    assert isinstance(last_ai_message, AIMessage)
+    
+    # 2. Must have usage metadata
+    assert last_ai_message.usage_metadata is not None
+    
+    # 3. Must exceed the summarization threshold
+    reported_tokens = last_ai_message.usage_metadata.get("total_tokens", -1)
+    assert reported_tokens >= threshold
+    
+    # 4. CRITICAL FIX: Must have model_provider metadata that matches 'litellm'
+    message_provider = last_ai_message.response_metadata.get("model_provider")
+    assert message_provider == "litellm"

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -73,41 +73,34 @@ def test_router_stream_options_set_for_all_providers():
     )
     assert stream_options == {"include_usage": True}
 
-def test_router_aimessage_passes_langchain_summarization_middleware():
-    """
-    Test that ChatLiteLLMRouter outputs pass LangChain's strict token counting guards.
-    Fixes Issue #152 where missing 'model_provider' caused SummarizationMiddleware to fail.
-    """
+def test_router_create_chat_result_sets_model_provider():
+    """Router non-streaming path must set model_provider. Fixes #152."""
     router = test_router()
     llm = ChatLiteLLMRouter(router=router)
-
     mock_response = {
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": "Test response"},
-                "finish_reason": "stop",
-            }
-        ],
+        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
-
-    # Router's _create_chat_result requires the metadata kwarg
     result = llm._create_chat_result(mock_response, metadata={})
-    last_ai_message = result.generations[0].message
-    
-    # ── Simulate the exact logic from SummarizationMiddleware ──
-    threshold = 10
-    
-    # 1. Must be an AIMessage
-    assert isinstance(last_ai_message, AIMessage)
-    
-    # 2. Must have usage metadata
-    assert last_ai_message.usage_metadata is not None
-    
-    # 3. Must exceed the summarization threshold
-    reported_tokens = last_ai_message.usage_metadata.get("total_tokens", -1)
-    assert reported_tokens >= threshold
-    
-    # 4. CRITICAL FIX: Must have model_provider metadata that matches 'litellm'
-    message_provider = last_ai_message.response_metadata.get("model_provider")
-    assert message_provider == "litellm"
+    msg = result.generations[0].message
+    assert isinstance(msg, AIMessage)
+    assert msg.response_metadata.get("model_provider") == "litellm"
+
+
+def test_router_stream_sets_model_provider_in_response_metadata():
+    """Router first streaming chunk must carry model_provider. Fixes #152."""
+    from unittest.mock import patch
+
+    router = test_router()
+    llm = ChatLiteLLMRouter(router=router)
+    fake_chunks = [
+        {"choices": [{"delta": {"role": "assistant", "content": "hel"}}], "usage": None},
+        {"choices": [{"delta": {"content": "lo"}}], "usage": None},
+        {"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}},
+    ]
+
+    with patch.object(llm.router, "completion", return_value=iter(fake_chunks)):
+        chunks = list(llm._stream([]))
+
+    assert chunks[0].message.response_metadata.get("model_provider") == "litellm"
+    assert chunks[1].message.response_metadata == {}


### PR DESCRIPTION
Fixes #152

Adds `"model_provider": "litellm"` to `response_metadata` on all
`AIMessage` objects produced by `ChatLiteLLM` and `ChatLiteLLMRouter`,
and overrides `_get_ls_params()` to return `ls_provider="litellm"`.

Without this, `SummarizationMiddleware._should_summarize_based_on_reported_tokens()`
always returned `False` despite correct token counts in `usage_metadata` — the
provider guard `message_provider == self.model._get_ls_params().get("ls_provider")`
short-circuited because `model_provider` was absent from `response_metadata`
and `ls_provider` was absent from `_get_ls_params()`.

**Changed files:**
- `langchain_litellm/chat_models/litellm.py`: set `model_provider` in
  `_create_chat_result`, `_stream`, `_astream`; add `_get_ls_params` override
- `langchain_litellm/chat_models/litellm_router.py`: set `model_provider` in
  `_create_chat_result`, `_stream`, `_astream`

**Verification:** Newly added unit tests for this functionality pass