### PR TITLE
fix: strip thinking/redacted_thinking blocks from messages sent to non-Anthropic providers

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -340,7 +340,7 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
                 # Skip tool_use / tool_call blocks — these are handled via
                 # message.tool_calls and must not leak into content sent to
                 # providers that don't understand them (e.g. OpenAI).
-                elif item.get("type") in ("tool_use", "tool_call"):
+                elif item.get("type") in ("tool_use", "tool_call", "thinking", "redacted_thinking"):
                     continue
 
                 # Pass through standard text blocks or other unrecognized dict formats unchanged
@@ -374,6 +374,10 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
             ]
         elif "tool_calls" in message.additional_kwargs:
             message_dict["tool_calls"] = message.additional_kwargs["tool_calls"]
+        # Forward reasoning_content so LiteLLM can inject thinking blocks for
+        # Anthropic while leaving OpenAI-bound messages clean.
+        if "reasoning_content" in message.additional_kwargs:
+            message_dict["reasoning_content"] = message.additional_kwargs["reasoning_content"]
     elif isinstance(message, SystemMessage):
         message_dict["role"] = "system"
     elif isinstance(message, FunctionMessage):

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -528,3 +528,23 @@ def test_get_ls_params_sets_ls_provider() -> None:
     llm_with_name = ChatLiteLLM(model="gpt-4", model_name="my-deployment", api_key="fake")
     params = llm_with_name._get_ls_params()
     assert params["ls_model_name"] == "my-deployment"
+
+def test_convert_message_to_dict_strips_thinking_blocks() -> None:
+    """thinking/redacted_thinking blocks must not reach non-Anthropic providers."""
+    from langchain_litellm.chat_models.litellm import _convert_message_to_dict
+
+    msg = AIMessage(
+        content=[
+            {"type": "thinking", "thinking": "internal reasoning"},
+            {"type": "redacted_thinking", "data": "encrypted"},
+            {"type": "text", "text": "hello"},
+        ],
+        additional_kwargs={"reasoning_content": "internal reasoning"},
+    )
+    d = _convert_message_to_dict(msg)
+
+    types = [block.get("type") for block in d["content"]]
+    assert "thinking" not in types
+    assert "redacted_thinking" not in types
+    assert {"type": "text", "text": "hello"} in d["content"]
+    assert d["reasoning_content"] == "internal reasoning"


### PR DESCRIPTION
# Fixes #139 

## Summary

`thinking` and `redacted_thinking` content blocks (injected by
`_inject_reasoning_content_into_content` when handling Claude extended
thinking responses) were not filtered out in `_convert_message_to_dict`
before messages were sent to the provider. OpenAI-compatible endpoints
reject these with:

> BadRequestError: messages.content expected a string or array of
> objects, but got [{"type":"thinking","thinking":"..."}]

## Root cause

`_convert_message_to_dict` already filters `tool_use` and `tool_call`
blocks from content. No equivalent filter existed for `thinking` /
`redacted_thinking`.

## Fix

- Add `"thinking"` and `"redacted_thinking"` to the content block
  filter in `_convert_message_to_dict`
- Forward `reasoning_content` from `additional_kwargs` into the message
  dict so LiteLLM can reconstruct the thinking block natively for
  Anthropic on the outbound side

`ChatLiteLLMRouter` inherits `_create_message_dicts` from `ChatLiteLLM`
so the fix covers both classes with no change to `litellm_router.py`.

## Verification

`make test` passes.