### PR TITLE
fix: remove global litellm module mutations from _client_params (#132)

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -467,37 +467,14 @@ class ChatLiteLLM(BaseChatModel):
 
     @property
     def _client_params(self) -> Dict[str, Any]:
-        """Get the parameters used for the openai client."""
-        set_model_value = self.model
-        if self.model_name is not None:
-            set_model_value = self.model_name
-        self.client.api_base = self.api_base
-        self.client.api_key = self.api_key
-        for named_api_key in [
-            "openai_api_key",
-            "azure_api_key",
-            "anthropic_api_key",
-            "replicate_api_key",
-            "cohere_api_key",
-            "openrouter_api_key",
-        ]:
-            if api_key_value := getattr(self, named_api_key):
-                setattr(
-                    self.client,
-                    named_api_key.replace("_api_key", "_key"),
-                    api_key_value,
-                )
-        self.client.organization = self.organization
+        """Get the parameters used for the OpenAI client."""
         creds: Dict[str, Any] = {
-            "model": set_model_value,
             "timeout": self.request_timeout,
             "api_base": self.api_base,
             "api_key": self.api_key,
+            "organization": self.organization,
         }
-        # Forward any extra headers to the client and include in params
         if self.extra_headers is not None:
-            # set attribute on client for runtime usage
-            setattr(self.client, "extra_headers", self.extra_headers)
             creds["extra_headers"] = self.extra_headers
         return {**self._default_params, **creds}
 

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -1,20 +1,25 @@
 """Test chat model integration."""
 
+# stdlib
 import logging
-from typing import Any, Type
+from typing import Any
+from unittest.mock import patch
 
+# third-party
+import litellm
 import pytest
 from langchain_core.exceptions import OutputParserException
-from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 from langchain_core.runnables import RunnableLambda
-from langchain_tests.unit_tests import ChatModelUnitTests
 from litellm.types.utils import ChatCompletionDeltaToolCall, Delta, Function
 from pydantic import BaseModel
 
+# first-party
 from langchain_litellm.chat_models import ChatLiteLLM
 from langchain_litellm.chat_models.litellm import (
     _convert_delta_to_message_chunk,
     _convert_dict_to_message,
+    _convert_message_to_dict,
     _create_usage_metadata,
     _inject_reasoning_content_into_content,
 )
@@ -67,8 +72,6 @@ def test_convert_dict_to_tool_message() -> None:
     """Ensure tool role dicts convert to ToolMessage."""
     mock_dict = {"role": "tool", "content": "result", "tool_call_id": "123"}
     message = _convert_dict_to_message(mock_dict)
-    from langchain_core.messages import ToolMessage
-
     assert isinstance(message, ToolMessage)
     assert message.content == "result"
     assert message.tool_call_id == "123"
@@ -501,7 +504,6 @@ def test_create_chat_result_sets_model_provider() -> None:
 
 def test_stream_sets_model_provider_in_response_metadata() -> None:
     """First streaming chunk must carry model_provider. Fixes #152."""
-    from unittest.mock import patch
 
     llm = ChatLiteLLM(model="gpt-4", api_key="fake")
     fake_chunks = [
@@ -531,7 +533,6 @@ def test_get_ls_params_sets_ls_provider() -> None:
 
 def test_convert_message_to_dict_strips_thinking_blocks() -> None:
     """thinking/redacted_thinking blocks must not reach non-Anthropic providers."""
-    from langchain_litellm.chat_models.litellm import _convert_message_to_dict
 
     msg = AIMessage(
         content=[
@@ -548,3 +549,32 @@ def test_convert_message_to_dict_strips_thinking_blocks() -> None:
     assert "redacted_thinking" not in types
     assert {"type": "text", "text": "hello"} in d["content"]
     assert d["reasoning_content"] == "internal reasoning"
+
+def test_client_params_does_not_mutate_litellm_globals() -> None:
+    """_client_params must not write instance config to litellm module globals. Fixes #132."""
+    before = {
+        "api_base": litellm.api_base,
+        "api_key": litellm.api_key,
+        "organization": getattr(litellm, "organization", None),
+    }
+
+    llm = ChatLiteLLM(
+        model="azure/gpt-4o",
+        api_base="https://my-azure.openai.azure.com",
+        api_key="azure-key",
+        organization="my-org",
+        extra_headers={"X-Custom": "value"},
+    )
+    params = llm._client_params
+
+    # globals must be untouched
+    assert litellm.api_base == before["api_base"]
+    assert litellm.api_key == before["api_key"]
+    assert getattr(litellm, "organization", None) == before["organization"]
+    assert getattr(litellm, "extra_headers", None) != {"X-Custom": "value"}
+
+    # values must be present in the returned per-call params instead
+    assert params["api_base"] == "https://my-azure.openai.azure.com"
+    assert params["api_key"] == "azure-key"
+    assert params["organization"] == "my-org"
+    assert params["extra_headers"] == {"X-Custom": "value"}


### PR DESCRIPTION
Fixes #132

`_client_params` was writing `api_base`, `api_key`, `organization`,
named provider keys, and `extra_headers` directly onto the `litellm`
module object (`self.client` is the `litellm` module itself), causing
cross-instance state contamination and race conditions in async and
concurrent applications where multiple `ChatLiteLLM` instances with
different providers coexist in the same process.

All mutated values were already redundant — they are passed per-call
via `litellm.completion(**kwargs)`. Removed all global writes and added
`organization` to the per-call `creds` dict. Also removed the duplicate
`model` computation, which was already handled by `_default_params`.

`ChatLiteLLMRouter` inherits `_client_params` from `ChatLiteLLM` so
the fix covers both classes with no change to `litellm_router.py`.

**Verification:** `make test` passes.