### PR TITLE
ci(release): switch to human-in-the-loop PyPI publish via draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: Release
-
 on:
   push:
     branches:
@@ -9,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Last-resort escape hatch only. Please enter the `tag` to be published to PyPi manually (e.g. `langchain-litellm==x.x.x`) or leave empty to skip publishing to PyPi. Use this only if the release:published trigger failed."
+        description: "Last-resort escape hatch only. Enter the tag to publish to PyPI manually (e.g. langchain-litellm-v0.x.x) or leave empty to skip. Use only if release:published trigger failed."
         required: false
 
 permissions:
@@ -25,8 +24,6 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v5
@@ -66,19 +63,13 @@ jobs:
           fi
 
   pypi-publish:
-    needs: [release-please]
-    # Runs in three cases:
-    # 1. release-please creates a release (push to main flow)
-    # 2. A GitHub Release is published manually in the UI (release: published flow)
-    # 3. Last-resort escape hatch via workflow_dispatch with a tag input
-    # always() is required so this job is not skipped when release-please is skipped (cases 2 & 3).
+    # Runs in two cases:
+    # 1. A draft GitHub Release is reviewed and published in the UI (release: published flow)
+    # 2. Last-resort escape hatch via workflow_dispatch with a tag input
+    # No always() needed — this job is fully decoupled from release-please.
     if: |
-      always() &&
-      (
-        (needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true') ||
-        github.event_name == 'release' ||
-        (github.event_name == 'workflow_dispatch' && inputs.tag != '')
-      )
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.tag != '')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -91,8 +82,7 @@ jobs:
           ref: >-
             ${{
               github.event_name == 'workflow_dispatch' && inputs.tag ||
-              github.event_name == 'release' && github.ref ||
-              needs.release-please.outputs.tag_name
+              github.ref
             }}
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 .venv/
 .ruff_cache/
 .pytest_cache/
+.mypy_cache/
 .vscode/
 .benchmarks/
 dist/

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "component": "langchain-litellm",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
+      "draft": true,
       "extra-files": [
         "pyproject.toml"
       ]


### PR DESCRIPTION
## What

- Set `draft: true` in `release-please-config.json` so release-please
  creates draft GitHub releases instead of publishing them directly
- Remove the `always()` wrapper and `release_created` branch from
  `pypi-publish`'s `if` condition — both are now dead code since
  release-please no longer publishes a release event
- Simplify the checkout `ref` expression: collapse
  `github.event_name == 'release' && github.ref` into just `github.ref`
  since it's the correct value for both the `release` and unmatched cases
- Add `.mypy_cache/` to `.gitignore`

## Why

Previously, merging the release PR caused release-please to immediately
publish a GitHub release, which fired `release: published`, which
triggered PyPI publish — all without any human review. This also caused
a dual-trigger race where both the `release_created` path and the
`release: published` path would queue a PyPI publish job simultaneously.

The new flow: merge release PR → release-please creates a **draft**
release → maintainer reviews and edits release notes → clicks publish →
PyPI publish fires. One explicit human action, one trigger path, no race.

The `workflow_dispatch` escape hatch is unchanged for cases where the
release PR was bypassed entirely.