### PR TITLE
test: enable has_structured_output and supports_image_inputs in standard test suites

### DIFF
--- a/tests/integration_tests/test_router.py
+++ b/tests/integration_tests/test_router.py
@@ -38,7 +38,7 @@ class TestChatLiteLLMRouterIntegration(ChatModelIntegrationTests):
 
     @property
     def has_structured_output(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_json_mode(self) -> bool:
@@ -46,7 +46,7 @@ class TestChatLiteLLMRouterIntegration(ChatModelIntegrationTests):
 
     @property
     def supports_image_inputs(self) -> bool:
-        return False
+        return True
 
     @property
     def returns_usage_metadata(self) -> bool:

--- a/tests/integration_tests/test_standard.py
+++ b/tests/integration_tests/test_standard.py
@@ -30,7 +30,7 @@ class TestChatLiteLLMIntegration(ChatModelIntegrationTests):
 
     @property
     def has_structured_output(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_json_mode(self) -> bool:
@@ -38,7 +38,7 @@ class TestChatLiteLLMIntegration(ChatModelIntegrationTests):
 
     @property
     def supports_image_inputs(self) -> bool:
-        return False
+        return True
 
     @property
     def returns_usage_metadata(self) -> bool:

--- a/tests/unit_tests/test_standard.py
+++ b/tests/unit_tests/test_standard.py
@@ -42,7 +42,7 @@ class TestChatLiteLLMUnit(ChatModelUnitTests):
 
     @property
     def has_structured_output(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_json_mode(self) -> bool:
@@ -50,7 +50,7 @@ class TestChatLiteLLMUnit(ChatModelUnitTests):
 
     @property
     def supports_image_inputs(self) -> bool:
-        return False
+        return True
 
     @property
     def returns_usage_metadata(self) -> bool:

--- a/tests/unit_tests/test_standard_router.py
+++ b/tests/unit_tests/test_standard_router.py
@@ -33,7 +33,7 @@ class TestChatLiteLLMRouterUnit(ChatModelUnitTests):
 
     @property
     def has_structured_output(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_json_mode(self) -> bool:
@@ -41,7 +41,7 @@ class TestChatLiteLLMRouterUnit(ChatModelUnitTests):
 
     @property
     def supports_image_inputs(self) -> bool:
-        return False
+        return True
 
     @property
     def returns_usage_metadata(self) -> bool:


### PR DESCRIPTION
`has_structured_output` and `supports_image_inputs` were declared `False` across
all four standard test classes, causing `langchain_tests` to silently skip the
corresponding test suites. Both features are fully implemented:

- `with_structured_output` supports `function_calling`, `json_schema`, and
  `json_mode` methods on `ChatLiteLLM`, inherited by `ChatLiteLLMRouter`.
- Multimodal image content is handled in `_convert_message_to_dict` via
  `is_data_content_block` / `convert_to_openai_data_block`, also inherited
  by the router.

Flips both flags to `True` in all four standard test classes and updates the
model features table in the docs notebook to reflect the current state.