### PR TITLE
test: enable supports_json_mode in standard test suites

### DIFF
--- a/tests/integration_tests/test_router.py
+++ b/tests/integration_tests/test_router.py
@@ -42,7 +42,7 @@ class TestChatLiteLLMRouterIntegration(ChatModelIntegrationTests):
 
     @property
     def supports_json_mode(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_image_inputs(self) -> bool:

--- a/tests/integration_tests/test_standard.py
+++ b/tests/integration_tests/test_standard.py
@@ -34,7 +34,7 @@ class TestChatLiteLLMIntegration(ChatModelIntegrationTests):
 
     @property
     def supports_json_mode(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_image_inputs(self) -> bool:

--- a/tests/unit_tests/test_standard.py
+++ b/tests/unit_tests/test_standard.py
@@ -46,7 +46,7 @@ class TestChatLiteLLMUnit(ChatModelUnitTests):
 
     @property
     def supports_json_mode(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_image_inputs(self) -> bool:

--- a/tests/unit_tests/test_standard_router.py
+++ b/tests/unit_tests/test_standard_router.py
@@ -37,7 +37,7 @@ class TestChatLiteLLMRouterUnit(ChatModelUnitTests):
 
     @property
     def supports_json_mode(self) -> bool:
-        return False
+        return True
 
     @property
     def supports_image_inputs(self) -> bool:


### PR DESCRIPTION
`supports_json_mode` was declared `False` across all four standard test classes, causing `langchain_tests` to skip the JSON mode test suite entirely.

The `json_mode` method is implemented in `with_structured_output`:
- binds `response_format={"type": "json_object"}` via `self.bind`
- uses `PydanticOutputParser` or `JsonOutputParser` depending on schema type
- inherited by `ChatLiteLLMRouter` unchanged

`gpt-4o-mini` (used in integration tests) supports `response_format` natively.

Flips `supports_json_mode` to `True` in all four standard test classes.