### PR TITLE
test: rename factory helpers to avoid PytestReturnNotNoneWarning

### DIFF
--- a/tests/unit_tests/test_embeddings_router.py
+++ b/tests/unit_tests/test_embeddings_router.py
@@ -7,7 +7,7 @@ import pytest
 from langchain_tests.unit_tests import EmbeddingsUnitTests
 
 from langchain_litellm.embeddings import LiteLLMEmbeddingsRouter
-from tests.utils import mock_embedding_response, test_embedding_router
+from tests.utils import mock_embedding_response, make_embedding_router
 
 
 class TestLiteLLMEmbeddingsRouterUnit(EmbeddingsUnitTests):
@@ -18,20 +18,20 @@ class TestLiteLLMEmbeddingsRouterUnit(EmbeddingsUnitTests):
     @property
     def embedding_model_params(self) -> dict:
         return {
-            "router": test_embedding_router(),
+            "router": make_embedding_router(),
         }
 
 
 class TestLiteLLMEmbeddingsRouterParams:
     def test_router_stored(self):
         """Test that the router instance is stored."""
-        router = test_embedding_router()
+        router = make_embedding_router()
         embeddings = LiteLLMEmbeddingsRouter(router=router)
         assert embeddings.router is router
 
     def test_router_params_exclude_none(self):
         """Test that None-valued params are excluded from router calls."""
-        router = test_embedding_router()
+        router = make_embedding_router()
         embeddings = LiteLLMEmbeddingsRouter(router=router)
         params = embeddings._get_router_params()
         assert "timeout" not in params

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -6,12 +6,12 @@ from langchain_core.messages import AIMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 
 from langchain_litellm.chat_models import ChatLiteLLMRouter
-from tests.utils import test_router
+from tests.utils import make_router
 
 
 def test_router_provider_specific_fields_in_chat_result():
     """Test that Router preserves top-level provider_specific_fields."""
-    router = test_router()
+    router = make_router()
     llm = ChatLiteLLMRouter(router=router)
 
     mock_response = {
@@ -36,7 +36,7 @@ def test_router_provider_specific_fields_in_chat_result():
 
 def test_router_create_chat_result_sets_usage_metadata():
     """Router _create_chat_result should set usage_metadata on AIMessage."""
-    router = test_router()
+    router = make_router()
     llm = ChatLiteLLMRouter(router=router)
 
     mock_response = {
@@ -64,7 +64,7 @@ def test_router_create_chat_result_sets_usage_metadata():
 
 def test_router_stream_options_set_for_all_providers():
     """Router _stream must set stream_options for non-OpenAI providers."""
-    router = test_router()
+    router = make_router()
     llm = ChatLiteLLMRouter(router=router)
     stream_options = (
         llm.stream_options
@@ -75,7 +75,7 @@ def test_router_stream_options_set_for_all_providers():
 
 def test_router_create_chat_result_sets_model_provider():
     """Router non-streaming path must set model_provider. Fixes #152."""
-    router = test_router()
+    router = make_router()
     llm = ChatLiteLLMRouter(router=router)
     mock_response = {
         "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
@@ -91,7 +91,7 @@ def test_router_stream_sets_model_provider_in_response_metadata():
     """Router first streaming chunk must carry model_provider. Fixes #152."""
     from unittest.mock import patch
 
-    router = test_router()
+    router = make_router()
     llm = ChatLiteLLMRouter(router=router)
     fake_chunks = [
         {"choices": [{"delta": {"role": "assistant", "content": "hel"}}], "usage": None},

--- a/tests/unit_tests/test_standard_router.py
+++ b/tests/unit_tests/test_standard_router.py
@@ -9,7 +9,7 @@ from langchain_core.messages import AIMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 
 from langchain_litellm.chat_models import ChatLiteLLMRouter
-from tests.utils import test_router
+from tests.utils import make_router
 
 
 class TestChatLiteLLMRouterUnit(ChatModelUnitTests):
@@ -20,7 +20,7 @@ class TestChatLiteLLMRouterUnit(ChatModelUnitTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "router": test_router(),
+            "router": make_router(),
         }
 
     @property

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from litellm import Router
 
 
-def test_router() -> Router:
+def make_router() -> Router:
     model_group_gpt4 = "gpt-4"
     model_group_to_test = "gpt-3.5-turbo"
     fake_model_prefix = "azure/fake-deployment-name-"
@@ -35,7 +35,7 @@ def test_router() -> Router:
     return Router(model_list)
 
 
-def test_embedding_router() -> Router:
+def make_embedding_router() -> Router:
     fake_api_key = "fakekeyvalue"
     model_list = [
         {


### PR DESCRIPTION
`tests/utils.py` defines `test_router()` and `test_embedding_router()` as
factory helpers that construct `Router` instances for use in test fixtures.
The `test_` prefix causes pytest to discover them as test functions when they
are imported into test modules, producing three spurious collections and three
`PytestReturnNotNoneWarning` warnings per run:

  test_embeddings_router.py::test_embedding_router returned <class 'litellm.router.Router'>
  test_router.py::test_router returned <class 'litellm.router.Router'>
  test_standard_router.py::test_router returned <class 'litellm.router.Router'>

This also inflated the reported pass count by 3 on every run.

Renames both helpers to `make_router()` and `make_embedding_router()` and
updates all call sites. No test logic changes.

Before: 122 collected, 118 passed, 4 skipped, 3 warnings
After:  119 collected, 115 passed, 4 skipped, 0 warnings