### PR TITLE
ci(pr-title-lint): remove warn-on-bypass job and bypass mechanism

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -31,8 +31,7 @@
 #
 # release-please parses the squash-merge commit (= this PR title) to generate
 # changelog entries and determine the next version bump. A non-conventional
-# title means no changelog entry unless a BEGIN_COMMIT_OVERRIDE block is
-# added to the PR description.
+# title means no changelog entry.
 
 name: "PR Title Lint"
 
@@ -41,7 +40,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, labeled, unlabeled]
+    types: [opened, edited, synchronize]
 
 jobs:
   lint-pr-title:
@@ -76,84 +75,3 @@ jobs:
             chore
             revert
           requireScope: false
-          ignoreLabels: |
-            ignore-lint-pr-title
-
-  warn-on-bypass:
-    name: "warn on bypass label"
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    concurrency:
-      group: pr-lint-bypass-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ignore-lint-pr-title') ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'ignore-lint-pr-title') ||
-      contains(github.event.pull_request.labels.*.name, 'ignore-lint-pr-title')
-    steps:
-      - name: "post or remove bypass-warning comment"
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request?.number;
-            if (!prNumber) {
-              core.setFailed('No PR number in payload.');
-              return;
-            }
-            const STICKY_MARKER = '<!-- pr-title-lint-bypass -->';
-            const BYPASS_LABEL = 'ignore-lint-pr-title';
-
-            async function findStickyComment() {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: prNumber, per_page: 100,
-              });
-              return comments.find(c => c.body && c.body.startsWith(STICKY_MARKER));
-            }
-
-            let liveLabels;
-            try {
-              ({ data: liveLabels } = await github.rest.issues.listLabelsOnIssue({
-                owner, repo, issue_number: prNumber,
-              }));
-            } catch (e) {
-              throw new Error(`Failed to fetch live labels for PR #${prNumber}: ${e.message}`);
-            }
-            const labelPresent = liveLabels.some(l => l.name === BYPASS_LABEL);
-
-            if (!labelPresent) {
-              try {
-                const existing = await findStickyComment();
-                if (existing) {
-                  await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
-                }
-              } catch (e) {
-                core.warning(`Could not clean up sticky comment: ${e.message}`);
-              }
-              return;
-            }
-
-            const body = [
-              STICKY_MARKER,
-              '⚠️ **PR title Conventional Commits lint is being bypassed.**',
-              '',
-              `This PR carries the \`${BYPASS_LABEL}\` label, which skips Conventional Commits validation on the title.`,
-              '',
-              '**Why this matters:** release-please parses the squash-merge commit message (= PR title) to generate changelog entries and determine the version bump. A non-conventional title means **no changelog entry** for this commit unless a `BEGIN_COMMIT_OVERRIDE` block is added to the PR description.',
-              '',
-              'Remove the label to re-enable the check, or add a `BEGIN_COMMIT_OVERRIDE` block so release-please still gets a parseable message.',
-            ].join('\n');
-
-            try {
-              const existing = await findStickyComment();
-              if (existing) {
-                if (existing.body !== body) {
-                  await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-                }
-              } else {
-                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
-              }
-            } catch (e) {
-              core.warning(`Could not post sticky comment: ${e.message}`);
-            }


### PR DESCRIPTION
`ignore-lint-pr-title` does not exist as a label and there are no plans
to ever bypass conventional commits on this repo. The `warn-on-bypass`
job is unreachable dead code that shows as a skipped check on every PR.

Removes:
- `warn-on-bypass` job and its `pull-requests: write` permission
- `ignoreLabels` from `amannn/action-semantic-pull-request` config
- `labeled` and `unlabeled` from trigger types (only needed for bypass)

`validate format` and the empty-scope rejection step are unchanged.