### PR TITLE
docs: replace generic wrapper descriptions in module docstrings

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -1,4 +1,4 @@
-"""Wrapper around LiteLLM's model I/O library."""
+"""LiteLLM chat model integration for LangChain."""
 
 from __future__ import annotations
 

--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -1,4 +1,4 @@
-"""Wrapper around LiteLLM's embedding API."""
+"""LiteLLM embedding model integration for LangChain."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
The reference docs at reference.langchain.com render each module's
first-line docstring as its description. Two modules still used the
old "Wrapper around X" convention:

- `embeddings/litellm.py`: "Wrapper around LiteLLM's embedding API."
- `chat_models/litellm.py`: "Wrapper around LiteLLM's model I/O library."

Updates both to be consistent with the rest of the codebase
(e.g., `embeddings/litellm_router.py`: "LiteLLM Router as LangChain
Embeddings model.").