### PR TITLE
docs: fix stale and inaccurate docstrings across chat model and embedding modules

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -94,7 +94,7 @@ def _create_retry_decorator(
         Union[AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun]
     ] = None,
 ) -> Callable[[Any], Any]:
-    """Returns a tenacity retry decorator, preconfigured to handle PaLM exceptions"""
+    """Return a tenacity retry decorator preconfigured for LiteLLM transient errors."""
     import litellm
 
     errors = [

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -85,7 +85,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChatLiteLLMException(Exception):
-    """Error with the `LiteLLM I/O` library"""
+    """Exception raised for errors in the LiteLLM integration."""
 
 
 def _create_retry_decorator(

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -448,7 +448,7 @@ class ChatLiteLLM(BaseChatModel):
 
     @property
     def _default_params(self) -> Dict[str, Any]:
-        """Get the default parameters for calling OpenAI API."""
+        """Get the default parameters for the LiteLLM completion call."""
         set_model_value = self.model
         if self.model_name is not None:
             set_model_value = self.model_name
@@ -467,7 +467,7 @@ class ChatLiteLLM(BaseChatModel):
 
     @property
     def _client_params(self) -> Dict[str, Any]:
-        """Get the parameters used for the OpenAI client."""
+        """Get the per-call parameters passed to litellm.completion."""
         creds: Dict[str, Any] = {
             "timeout": self.request_timeout,
             "api_base": self.api_base,
@@ -791,22 +791,22 @@ class ChatLiteLLM(BaseChatModel):
 
         Args:
             tools: A list of tool definitions to bind to this chat model.
-                Can be  a dictionary, pydantic model, callable, or BaseTool. Pydantic
+                Can be a dictionary, pydantic model, callable, or BaseTool. Pydantic
                 models, callables, and BaseTools will be automatically converted to
                 their schema dictionary representation.
-            tool_choice: Which tool to require the model to call. Options are:
+            tool_choice: Controls tool-calling behavior. Options are:
                 - str of the form ``"<<tool_name>>"``: calls <<tool_name>> tool.
                 - ``"auto"``:
                     automatically selects a tool (including no tool).
                 - ``"none"``:
                     does not call a tool.
                 - ``"any"`` or ``"required"`` or ``True``:
-                    forces least one tool to be called.
+                    forces at least one tool to be called.
                 - dict of the form:
                 ``{"type": "function", "function": {"name": <<tool_name>>}}``
                 - ``False`` or ``None``: no effect
             **kwargs: Any additional parameters to pass to the
-                :class:`~langchain.runnable.Runnable` constructor.
+                :class:`~langchain_core.runnables.Runnable` constructor.
         """
 
         formatted_tools = [convert_to_openai_tool(tool) for tool in tools]

--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -29,7 +29,7 @@ model_extra_key_name = "model_extra"  # nosec # incorrectly flagged as password
 
 
 def get_llm_output(usage: Any, **params: Any) -> dict:
-    """Get llm output from usage and params."""
+    """Build the llm_output dict from router usage and completion params."""
     llm_output = {token_usage_key_name: usage}
     # copy over metadata (metadata came from router completion call)
     metadata = params["metadata"]

--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -1,4 +1,4 @@
-"""LiteLLM Router as LangChain."""
+"""LiteLLM Router chat model integration for LangChain."""
 
 from typing import Any, AsyncIterator, Iterator, List, Mapping, Optional
 
@@ -41,7 +41,7 @@ def get_llm_output(usage: Any, **params: Any) -> dict:
 
 
 class ChatLiteLLMRouter(ChatLiteLLM):
-    """LiteLLM Router as LangChain Model."""
+    """LiteLLM Router-backed chat model."""
 
     router: Any
 

--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -26,7 +26,7 @@ def _create_retry_decorator(max_retries: int) -> Callable[[Any], Any]:
 
 
 class LiteLLMEmbeddings(BaseModel, Embeddings):
-    """LiteLLM embedding model.
+    """Embedding model that uses the LiteLLM API.
 
     Uses `litellm.embedding()` to support 100+ providers through a unified
     interface. All provider configuration (api_key, api_base, etc.) can be


### PR DESCRIPTION
Stale provider references (wrong tech named):
- `_create_retry_decorator`: "handle PaLM exceptions" → LiteLLM transient errors
- `_default_params`: "calling OpenAI API" → LiteLLM completion call
- `_client_params`: "OpenAI client" → litellm.completion

Stale library branding:
- `ChatLiteLLMException`: "`LiteLLM I/O` library" → LiteLLM integration

Vague helper docstring:
- `get_llm_output`: "Get llm output from usage and params." → describes what it actually builds

Typos in bind_tools docstring:
- Double space: "Can be  a dictionary" → "Can be a dictionary"
- Missing word: "forces least one tool" → "forces at least one tool"