### PR TITLE
refactor: hoist litellm import to module level in _create_retry_decor…

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -77,6 +77,7 @@ from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env, pre_init
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
+import litellm
 from litellm.types.utils import Delta
 from pydantic import BaseModel, Field
 from typing_extensions import is_typeddict
@@ -95,7 +96,6 @@ def _create_retry_decorator(
     ] = None,
 ) -> Callable[[Any], Any]:
     """Return a tenacity retry decorator preconfigured for LiteLLM transient errors."""
-    import litellm
 
     errors = [
         litellm.Timeout,


### PR DESCRIPTION
…ator

`from litellm.types.utils import Delta` already makes `litellm` a hard
dependency at module load time, so the deferred `import litellm` inside
`_create_retry_decorator` is redundant.

Move it to the top-level imports for consistency. The `try/except` guard
in `validate_environment` is intentional and preserved — it surfaces a
user-friendly error when litellm is not installed.