### PR TITLE
ci: add PR labeler for CC type and breaking labels

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,72 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+concurrency:
+  group: pr-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply CC type and breaking labels
+        uses: actions/github-script@bd9e8d567c4ca374eb63e9febefd10835cefb377 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title ?? '';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            // Parse the Conventional Commit type and breaking marker.
+            const match = title.match(/^([a-z]+)(?:\([^)]+\))?(!)?\s*:/);
+            const type = match?.[1] ?? null;
+            const isBreaking = Boolean(match?.[2]);
+
+            const TYPE_LABELS = {
+              feat: 'feat', fix: 'fix', docs: 'docs', refactor: 'refactor',
+              test: 'test', chore: 'chore', ci: 'ci', perf: 'perf', build: 'build',
+            };
+
+            // Every label this workflow may add or remove. Anything outside
+            // this set (triage, Dependabot, autorelease) is never touched.
+            const MANAGED = new Set([...Object.values(TYPE_LABELS), 'breaking']);
+
+            // What the title says the PR should carry.
+            const desired = new Set();
+            if (type && TYPE_LABELS[type]) desired.add(TYPE_LABELS[type]);
+            if (isBreaking) desired.add('breaking');
+
+            // What the PR carries right now.
+            const current = new Set(
+              (await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                owner, repo, issue_number, per_page: 100,
+              })).map(l => l.name)
+            );
+
+            // Add only the missing; remove only managed labels that no longer apply.
+            const toAdd = [...desired].filter(name => !current.has(name));
+            const toRemove = [...current].filter(name => MANAGED.has(name) && !desired.has(name));
+
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+            }
+            for (const name of toRemove) {
+              // Guard only fires if a human/another workflow removed the label
+              // in the read→write window — no longer an expected path.
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            core.info(`#${issue_number}: +[${toAdd}] -[${toRemove}]`);


### PR DESCRIPTION
Adds a workflow that auto-labels PRs from their Conventional Commit title. It parses the type prefix (feat, fix, docs, refactor, test, chore, ci, perf, build) and the breaking marker (`!`), then applies the matching type label plus a `breaking` label when the title declares one.

The workflow only touches its own managed label set, so triage, Dependabot, and autorelease labels are never added or removed. It is idempotent: it adds only labels that are missing and removes only managed labels that no longer match the current title, so editing a title (e.g. `fix` to `feat!`) keeps the labels in sync on the next `edited` event.

It runs on `pull_request_target` so it has the write access needed to label PRs originating from forks. This is a safe use of that trigger: the job never checks out or executes PR code, it only reads `pull_request.title` and calls the labels API via `actions/github-script` (pinned to a full commit SHA). Workflow permissions are `contents: read`, with `pull-requests: write` scoped to the job alone.