### PR TITLE
refactor: add missing type annotations and fix mypy override errors

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply CC type and breaking labels
-        uses: actions/github-script@bd9e8d567c4ca374eb63e9febefd10835cefb377 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -30,12 +30,12 @@ from langchain_core.callbacks import (
 )
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import LanguageModelInput
+from langchain_core.language_models.base import LangSmithParams
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
     agenerate_from_stream,
     generate_from_stream,
 )
-from langchain_core.language_models.base import LangSmithParams
 from langchain_core.language_models.llms import create_base_retry_decorator
 from langchain_core.messages import (
     AIMessage,

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -307,7 +307,7 @@ def _convert_delta_to_message_chunk(
         return default_class(content=content)  # type: ignore[call-arg]
 
 
-def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
+def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> Dict[str, Any]:
     return {
         "type": "function",
         "id": tool_call["id"],
@@ -318,7 +318,7 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
     }
 
 
-def _convert_message_to_dict(message: BaseMessage) -> dict:
+def _convert_message_to_dict(message: BaseMessage) -> Dict[str, Any]:
     # Capture the original content from the message
     content = message.content
 
@@ -1088,7 +1088,7 @@ def _create_usage_metadata(token_usage: Any) -> UsageMetadata:
     return usage_metadata
 
 
-def _ensure_additional_properties_false(schema_dict: dict) -> dict:
+def _ensure_additional_properties_false(schema_dict: Dict[str, Any]) -> Dict[str, Any]:
     """Recursively ensure additionalProperties is set to false for all objects."""
     if isinstance(schema_dict, dict):
         result = schema_dict.copy()

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -23,6 +23,7 @@ from typing import (
     cast,
 )
 
+import litellm
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -77,7 +78,6 @@ from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env, pre_init
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
-import litellm
 from litellm.types.utils import Delta
 from pydantic import BaseModel, Field
 from typing_extensions import is_typeddict
@@ -340,7 +340,12 @@ def _convert_message_to_dict(message: BaseMessage) -> Dict[str, Any]:
                 # Skip tool_use / tool_call blocks — these are handled via
                 # message.tool_calls and must not leak into content sent to
                 # providers that don't understand them (e.g. OpenAI).
-                elif item.get("type") in ("tool_use", "tool_call", "thinking", "redacted_thinking"):
+                elif item.get("type") in (
+                    "tool_use",
+                    "tool_call",
+                    "thinking",
+                    "redacted_thinking",
+                ):
                     continue
 
                 # Pass through standard text blocks or other unrecognized dict formats unchanged
@@ -377,7 +382,9 @@ def _convert_message_to_dict(message: BaseMessage) -> Dict[str, Any]:
         # Forward reasoning_content so LiteLLM can inject thinking blocks for
         # Anthropic while leaving OpenAI-bound messages clean.
         if "reasoning_content" in message.additional_kwargs:
-            message_dict["reasoning_content"] = message.additional_kwargs["reasoning_content"]
+            message_dict["reasoning_content"] = message.additional_kwargs[
+                "reasoning_content"
+            ]
     elif isinstance(message, SystemMessage):
         message_dict["role"] = "system"
     elif isinstance(message, FunctionMessage):
@@ -886,7 +893,7 @@ class ChatLiteLLM(BaseChatModel):
                     "Claude models when `thinking` is enabled. Tool calls may be "
                     "omitted; this runnable will raise OutputParserException when "
                     "no tool call is returned. Consider disabling `thinking` or "
-                    "using `method=\"json_schema\"`."
+                    'using `method="json_schema"`.'
                 )
                 warnings.warn(warning_message, stacklevel=2)
                 bind_kwargs = {}
@@ -991,7 +998,7 @@ class ChatLiteLLM(BaseChatModel):
             "n": self.n,
             "num_ctx": self.num_ctx,
         }
-    
+
     def _get_ls_params(
         self,
         stop: Optional[List[str]] = None,
@@ -1011,7 +1018,7 @@ class ChatLiteLLM(BaseChatModel):
         params["ls_provider"] = "litellm"
         params["ls_model_name"] = self.model_name or self.model
         return params
-    
+
     @property
     def _llm_type(self) -> str:
         return "litellm-chat"

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -35,6 +35,7 @@ from langchain_core.language_models.chat_models import (
     agenerate_from_stream,
     generate_from_stream,
 )
+from langchain_core.language_models.base import LangSmithParams
 from langchain_core.language_models.llms import create_base_retry_decorator
 from langchain_core.messages import (
     AIMessage,
@@ -1003,7 +1004,7 @@ class ChatLiteLLM(BaseChatModel):
         self,
         stop: Optional[List[str]] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> LangSmithParams:
         """Return LangSmith tracing parameters for this model.
 
         Overrides the base implementation to set ``ls_provider`` to ``"litellm"``

--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -257,7 +257,9 @@ class ChatLiteLLMRouter(ChatLiteLLM):
     # from
     # https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/chat_models/openai.py
     # but modified to handle LiteLLM Usage class
-    def _combine_llm_outputs(self, llm_outputs: List[Optional[Dict[str, Any]]]) -> Dict[str, Any]:
+    def _combine_llm_outputs(
+        self, llm_outputs: List[Optional[Dict[str, Any]]]
+    ) -> Dict[str, Any]:
         overall_token_usage: Dict[str, Any] = {}
         system_fingerprint = None
         for output in llm_outputs:

--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -1,6 +1,6 @@
 """LiteLLM Router chat model integration for LangChain."""
 
-from typing import Any, AsyncIterator, Iterator, List, Mapping, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional
 
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
@@ -28,7 +28,7 @@ token_usage_key_name = "token_usage"  # nosec # incorrectly flagged as password
 model_extra_key_name = "model_extra"  # nosec # incorrectly flagged as password
 
 
-def get_llm_output(usage: Any, **params: Any) -> dict:
+def get_llm_output(usage: Any, **params: Any) -> Dict[str, Any]:
     """Build the llm_output dict from router usage and completion params."""
     llm_output = {token_usage_key_name: usage}
     # copy over metadata (metadata came from router completion call)
@@ -257,8 +257,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
     # from
     # https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/chat_models/openai.py
     # but modified to handle LiteLLM Usage class
-    def _combine_llm_outputs(self, llm_outputs: List[Optional[dict]]) -> dict:
-        overall_token_usage: dict = {}
+    def _combine_llm_outputs(self, llm_outputs: List[Optional[Dict[str, Any]]]) -> Dict[str, Any]:
+        overall_token_usage: Dict[str, Any] = {}
         system_fingerprint = None
         for output in llm_outputs:
             if output is None:

--- a/tests/unit_tests/test_embeddings_router.py
+++ b/tests/unit_tests/test_embeddings_router.py
@@ -7,7 +7,7 @@ import pytest
 from langchain_tests.unit_tests import EmbeddingsUnitTests
 
 from langchain_litellm.embeddings import LiteLLMEmbeddingsRouter
-from tests.utils import mock_embedding_response, make_embedding_router
+from tests.utils import make_embedding_router, mock_embedding_response
 
 
 class TestLiteLLMEmbeddingsRouterUnit(EmbeddingsUnitTests):

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -2,7 +2,7 @@
 
 # stdlib
 import logging
-from typing import Any
+from typing import Any, Dict, Optional, Union
 from unittest.mock import patch
 
 # third-party
@@ -345,7 +345,10 @@ def test_bind_tools_any_becomes_required_without_thinking() -> None:
     ],
     ids=["any", "required", "True", "dict"],
 )
-def test_bind_tools_downgraded_with_thinking(tool_choice, caplog) -> None:  # type: ignore[no-untyped-def]
+def test_bind_tools_downgraded_with_thinking(
+    tool_choice: Union[str, bool, Dict[str, Any]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Forced tool_choice values should be downgraded to 'auto' when thinking
     is enabled, so the model can produce CoT text before tool calls.
     """
@@ -373,7 +376,7 @@ def test_bind_tools_downgraded_with_thinking(tool_choice, caplog) -> None:  # ty
     ids=["any", "required", "True", "dict"],
 )
 def test_bind_tools_not_downgraded_with_thinking_on_non_claude_models(
-    tool_choice,
+    tool_choice: Union[str, bool, Dict[str, Any]],
 ) -> None:
     """Forced tool choices should be preserved for non-Claude models."""
     llm = ChatLiteLLM(
@@ -391,7 +394,9 @@ def test_bind_tools_not_downgraded_with_thinking_on_non_claude_models(
     ["auto", "none", None, False],
     ids=["auto", "none", "None", "False"],
 )
-def test_bind_tools_non_forced_unchanged_with_thinking(tool_choice) -> None:
+def test_bind_tools_non_forced_unchanged_with_thinking(
+    tool_choice: Optional[Union[str, bool]],
+) -> None:
     """Non-forced tool_choice values should pass through untouched."""
     llm = ChatLiteLLM(
         model="anthropic/claude-sonnet-4-20250514",
@@ -407,7 +412,9 @@ def test_bind_tools_non_forced_unchanged_with_thinking(tool_choice) -> None:
     [None, {}, {"type": "disabled"}],
     ids=["None", "empty", "disabled"],
 )
-def test_bind_tools_no_downgrade_without_thinking_enabled(thinking_config) -> None:
+def test_bind_tools_no_downgrade_without_thinking_enabled(
+    thinking_config: Optional[Dict[str, Any]],
+) -> None:
     """tool_choice='any' should stay 'required' when thinking is not enabled."""
     kwargs: dict = {}
     if thinking_config is not None:
@@ -442,7 +449,7 @@ def test_with_structured_output_function_calling_warns_and_raises_for_claude_thi
     bind_kwargs: dict[str, Any] = {}
 
     class _FakeChatLiteLLM(ChatLiteLLM):
-        def bind_tools(self, tools, **kwargs):  # type: ignore[no-untyped-def]
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
             bind_kwargs.update(kwargs)
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
 
@@ -466,9 +473,9 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     """`include_raw` should surface the parsing error without dropping the raw message."""
 
     class _FakeChatLiteLLM(ChatLiteLLM):
-        def bind_tools(self, tools, **kwargs):  # type: ignore[no-untyped-def]
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
-
+    
     llm = _FakeChatLiteLLM(
         model="anthropic/claude-sonnet-4-20250514",
         api_key="fake",

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -449,7 +449,7 @@ def test_with_structured_output_function_calling_warns_and_raises_for_claude_thi
     bind_kwargs: dict[str, Any] = {}
 
     class _FakeChatLiteLLM(ChatLiteLLM):
-        def bind_tools(self, tools: Any, **kwargs: Any) -> Any: # type: ignore[override]
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:  # type: ignore[override]
             bind_kwargs.update(kwargs)
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
 
@@ -473,7 +473,7 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     """`include_raw` should surface the parsing error without dropping the raw message."""
 
     class _FakeChatLiteLLM(ChatLiteLLM):
-        def bind_tools(self, tools: Any, **kwargs: Any) -> Any: # type: ignore[override]
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:  # type: ignore[override]
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
 
     llm = _FakeChatLiteLLM(

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -475,7 +475,7 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     class _FakeChatLiteLLM(ChatLiteLLM):
         def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
-    
+
     llm = _FakeChatLiteLLM(
         model="anthropic/claude-sonnet-4-20250514",
         api_key="fake",
@@ -496,11 +496,14 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     assert result["parsed"] is None
     assert isinstance(result["parsing_error"], OutputParserException)
 
+
 def test_create_chat_result_sets_model_provider() -> None:
     """Non-streaming path must set model_provider. Fixes #152."""
     llm = ChatLiteLLM(model="gpt-4", api_key="fake")
     mock_response = {
-        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "choices": [
+            {"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}
+        ],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
     result = llm._create_chat_result(mock_response)
@@ -514,12 +517,20 @@ def test_stream_sets_model_provider_in_response_metadata() -> None:
 
     llm = ChatLiteLLM(model="gpt-4", api_key="fake")
     fake_chunks = [
-        {"choices": [{"delta": {"role": "assistant", "content": "hel"}}], "usage": None},
+        {
+            "choices": [{"delta": {"role": "assistant", "content": "hel"}}],
+            "usage": None,
+        },
         {"choices": [{"delta": {"content": "lo"}}], "usage": None},
-        {"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}},
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+        },
     ]
 
-    with patch.object(ChatLiteLLM, "completion_with_retry", return_value=iter(fake_chunks)):
+    with patch.object(
+        ChatLiteLLM, "completion_with_retry", return_value=iter(fake_chunks)
+    ):
         chunks = list(llm._stream([]))
 
     assert chunks[0].message.response_metadata.get("model_provider") == "litellm"
@@ -534,9 +545,12 @@ def test_get_ls_params_sets_ls_provider() -> None:
     assert params["ls_model_name"] == "gpt-4"
 
     # model_name takes precedence over model when set
-    llm_with_name = ChatLiteLLM(model="gpt-4", model_name="my-deployment", api_key="fake")
+    llm_with_name = ChatLiteLLM(
+        model="gpt-4", model_name="my-deployment", api_key="fake"
+    )
     params = llm_with_name._get_ls_params()
     assert params["ls_model_name"] == "my-deployment"
+
 
 def test_convert_message_to_dict_strips_thinking_blocks() -> None:
     """thinking/redacted_thinking blocks must not reach non-Anthropic providers."""
@@ -556,6 +570,7 @@ def test_convert_message_to_dict_strips_thinking_blocks() -> None:
     assert "redacted_thinking" not in types
     assert {"type": "text", "text": "hello"} in d["content"]
     assert d["reasoning_content"] == "internal reasoning"
+
 
 def test_client_params_does_not_mutate_litellm_globals() -> None:
     """_client_params must not write instance config to litellm module globals. Fixes #132."""

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -449,7 +449,7 @@ def test_with_structured_output_function_calling_warns_and_raises_for_claude_thi
     bind_kwargs: dict[str, Any] = {}
 
     class _FakeChatLiteLLM(ChatLiteLLM):
-        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any: # type: ignore[override]
             bind_kwargs.update(kwargs)
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
 
@@ -473,7 +473,7 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
     """`include_raw` should surface the parsing error without dropping the raw message."""
 
     class _FakeChatLiteLLM(ChatLiteLLM):
-        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any: # type: ignore[override]
             return RunnableLambda(lambda _: AIMessage(content="plain text"))
 
     llm = _FakeChatLiteLLM(
@@ -491,6 +491,7 @@ def test_with_structured_output_include_raw_preserves_raw_for_claude_thinking() 
 
     result = structured.invoke("Return structured output.")
 
+    assert isinstance(result, dict)
     assert isinstance(result["raw"], AIMessage)
     assert result["raw"].content == "plain text"
     assert result["parsed"] is None

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -27,6 +27,7 @@ def test_router_provider_specific_fields_in_chat_result() -> None:
 
     result = llm._create_chat_result(mock_response, metadata={})
 
+    assert result.llm_output is not None
     assert "provider_specific_fields" in result.llm_output
     assert (
         result.llm_output["provider_specific_fields"]["citations"][0]["source"]

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -73,12 +73,15 @@ def test_router_stream_options_set_for_all_providers() -> None:
     )
     assert stream_options == {"include_usage": True}
 
+
 def test_router_create_chat_result_sets_model_provider() -> None:
     """Router non-streaming path must set model_provider. Fixes #152."""
     router = make_router()
     llm = ChatLiteLLMRouter(router=router)
     mock_response = {
-        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "choices": [
+            {"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}
+        ],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
     result = llm._create_chat_result(mock_response, metadata={})
@@ -94,9 +97,15 @@ def test_router_stream_sets_model_provider_in_response_metadata() -> None:
     router = make_router()
     llm = ChatLiteLLMRouter(router=router)
     fake_chunks = [
-        {"choices": [{"delta": {"role": "assistant", "content": "hel"}}], "usage": None},
+        {
+            "choices": [{"delta": {"role": "assistant", "content": "hel"}}],
+            "usage": None,
+        },
         {"choices": [{"delta": {"content": "lo"}}], "usage": None},
-        {"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}},
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+        },
     ]
 
     with patch.object(llm.router, "completion", return_value=iter(fake_chunks)):

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -9,7 +9,7 @@ from langchain_litellm.chat_models import ChatLiteLLMRouter
 from tests.utils import make_router
 
 
-def test_router_provider_specific_fields_in_chat_result():
+def test_router_provider_specific_fields_in_chat_result() -> None:
     """Test that Router preserves top-level provider_specific_fields."""
     router = make_router()
     llm = ChatLiteLLMRouter(router=router)
@@ -34,7 +34,7 @@ def test_router_provider_specific_fields_in_chat_result():
     )
 
 
-def test_router_create_chat_result_sets_usage_metadata():
+def test_router_create_chat_result_sets_usage_metadata() -> None:
     """Router _create_chat_result should set usage_metadata on AIMessage."""
     router = make_router()
     llm = ChatLiteLLMRouter(router=router)
@@ -62,7 +62,7 @@ def test_router_create_chat_result_sets_usage_metadata():
     assert msg.usage_metadata["total_tokens"] == 20
 
 
-def test_router_stream_options_set_for_all_providers():
+def test_router_stream_options_set_for_all_providers() -> None:
     """Router _stream must set stream_options for non-OpenAI providers."""
     router = make_router()
     llm = ChatLiteLLMRouter(router=router)
@@ -73,7 +73,7 @@ def test_router_stream_options_set_for_all_providers():
     )
     assert stream_options == {"include_usage": True}
 
-def test_router_create_chat_result_sets_model_provider():
+def test_router_create_chat_result_sets_model_provider() -> None:
     """Router non-streaming path must set model_provider. Fixes #152."""
     router = make_router()
     llm = ChatLiteLLMRouter(router=router)
@@ -87,7 +87,7 @@ def test_router_create_chat_result_sets_model_provider():
     assert msg.response_metadata.get("model_provider") == "litellm"
 
 
-def test_router_stream_sets_model_provider_in_response_metadata():
+def test_router_stream_sets_model_provider_in_response_metadata() -> None:
     """Router first streaming chunk must carry model_provider. Fixes #152."""
     from unittest.mock import patch
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 from typing import List
-
 from unittest.mock import MagicMock
 
 from litellm import Router

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from unittest.mock import MagicMock
 
 from litellm import Router
@@ -56,7 +58,7 @@ def make_embedding_router() -> Router:
     return Router(model_list)
 
 
-def mock_embedding_response(texts):  # type: ignore[no-untyped-def]
+def mock_embedding_response(texts: List[str]) -> MagicMock:
     """Create a mock litellm embedding response."""
     mock_response = MagicMock()
     mock_response.data = [


### PR DESCRIPTION
Adds missing type annotations across source and test files, and fixes
the mypy errors that surfaced when running the type checker.

### Source changes

**langchain_litellm/chat_models/litellm.py**
- Replace bare `dict` return type with `Dict[str, Any]` in
  `_lc_tool_call_to_openai_tool_call`, `_convert_message_to_dict`, and
  `_ensure_additional_properties_false`.
- Fix `_get_ls_params` to return `LangSmithParams` instead of
  `Dict[str, Any]`. The parent `BaseChatModel` already declared this
  return type so the annotation was a silent override mismatch. Import
  `LangSmithParams` from `langchain_core.language_models.base`.

**langchain_litellm/chat_models/litellm_router.py**
- Add missing `Dict` to the typing import.
- Replace bare `dict` return type with `Dict[str, Any]` in
  `get_llm_output` and `_combine_llm_outputs`.

### Test changes

**tests/utils.py**
- Annotate `mock_embedding_response(texts: List[str]) -> MagicMock`;
  remove `# type: ignore[no-untyped-def]`.

**tests/unit_tests/test_litellm.py**
- Annotate parametrized fixture parameters with precise types
  (`Union[str, bool, Dict[str, Any]]`, `pytest.LogCaptureFixture`,
  `Optional[Dict[str, Any]]`).
- Add typed signatures to both `_FakeChatLiteLLM.bind_tools` stubs;
  replace the blanket `# type: ignore[no-untyped-def]` with the
  narrower `# type: ignore[override]` since these stubs intentionally
  omit `tool_choice` for test simplicity.
- Add `assert isinstance(result, dict)` before subscripting the
  `include_raw=True` invoke result (`dict | BaseModel` is not directly
  indexable).

**tests/unit_tests/test_router.py**
- Add `-> None` to all five test functions.
- Add `assert result.llm_output is not None` before accessing
  `llm_output` (`dict | None` is not directly indexable or iterable).

`make lint` (ruff check + ruff format + mypy) and `make test` both pass
cleanly. No behavior change.