### PR TITLE
feat(langchain-litellm): record package version in model metadata

### DIFF
--- a/langchain_litellm/__init__.py
+++ b/langchain_litellm/__init__.py
@@ -1,15 +1,7 @@
-from importlib import metadata
-
-from .chat_models import ChatLiteLLM, ChatLiteLLMRouter
-from .document_loaders import LiteLLMOCRLoader
-from .embeddings import LiteLLMEmbeddings, LiteLLMEmbeddingsRouter
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+from langchain_litellm._version import __version__
+from langchain_litellm.chat_models import ChatLiteLLM, ChatLiteLLMRouter
+from langchain_litellm.document_loaders import LiteLLMOCRLoader
+from langchain_litellm.embeddings import LiteLLMEmbeddings, LiteLLMEmbeddingsRouter
 
 __all__ = [
     "ChatLiteLLM",

--- a/langchain_litellm/_version.py
+++ b/langchain_litellm/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-litellm`."""
+
+__version__ = "0.6.6"  # x-release-please-version

--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -80,8 +80,10 @@ from langchain_core.utils import get_from_dict_or_env, pre_init
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
 from litellm.types.utils import Delta
-from pydantic import BaseModel, Field
-from typing_extensions import is_typeddict
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self, is_typeddict
+
+from langchain_litellm._version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -509,6 +511,12 @@ class ChatLiteLLM(BaseChatModel):
             return await self.client.acompletion(**kwargs)
 
         return await _completion_with_retry(**kwargs)
+
+    @model_validator(mode="after")
+    def _set_litellm_version(self) -> Self:
+        """Set package version in metadata."""
+        self._add_version("langchain-litellm", __version__)
+        return self
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "langchain-core>=1.2.21,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "litellm>=1.83.14,<2.0.0,!=1.82.7,!=1.82.8",
     "httpx>=0.28.1,<0.29.0",
     "cryptography>=46.0.5,<49.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": true,
       "extra-files": [
-        "pyproject.toml"
+        "pyproject.toml",
+        "langchain_litellm/_version.py"
       ]
     }
   },

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -15,6 +15,7 @@ from litellm.types.utils import ChatCompletionDeltaToolCall, Delta, Function
 from pydantic import BaseModel
 
 # first-party
+from langchain_litellm._version import __version__
 from langchain_litellm.chat_models import ChatLiteLLM
 from langchain_litellm.chat_models.litellm import (
     _convert_delta_to_message_chunk,
@@ -551,6 +552,37 @@ def test_get_ls_params_sets_ls_provider() -> None:
     )
     params = llm_with_name._get_ls_params()
     assert params["ls_model_name"] == "my-deployment"
+
+
+def test_metadata_versions() -> None:
+    """Test that metadata reports the correct version info."""
+    llm = ChatLiteLLM(model="gpt-4", api_key="fake")
+    assert llm.metadata is not None
+    assert llm.metadata["lc_versions"]["langchain-litellm"] == __version__
+
+
+def test_metadata_versions_preserves_user_versions() -> None:
+    """Test that user-provided version metadata is preserved."""
+    llm = ChatLiteLLM(
+        model="gpt-4",
+        api_key="fake",
+        metadata={"lc_versions": {"my-app": "2.0"}},
+    )
+    assert llm.metadata is not None
+    assert llm.metadata["lc_versions"]["my-app"] == "2.0"
+    assert llm.metadata["lc_versions"]["langchain-litellm"] == __version__
+
+
+def test_metadata_versions_replaces_non_dict_versions() -> None:
+    """Test that invalid version metadata is replaced with a warning."""
+    with pytest.warns(UserWarning, match="expected a dict"):
+        llm = ChatLiteLLM(
+            model="gpt-4",
+            api_key="fake",
+            metadata={"lc_versions": "garbage"},
+        )
+    assert llm.metadata is not None
+    assert llm.metadata["lc_versions"]["langchain-litellm"] == __version__
 
 
 def test_convert_message_to_dict_strips_thinking_blocks() -> None:

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -2,6 +2,7 @@
 
 from langchain_core.messages import AIMessage
 
+from langchain_litellm._version import __version__
 from langchain_litellm.chat_models import ChatLiteLLMRouter
 from tests.utils import make_router
 
@@ -70,6 +71,14 @@ def test_router_stream_options_set_for_all_providers() -> None:
         else {"include_usage": True}
     )
     assert stream_options == {"include_usage": True}
+
+
+def test_router_metadata_versions() -> None:
+    """Test that router metadata reports the correct version info."""
+    router = make_router()
+    llm = ChatLiteLLMRouter(router=router)
+    assert llm.metadata is not None
+    assert llm.metadata["lc_versions"]["langchain-litellm"] == __version__
 
 
 def test_router_create_chat_result_sets_model_provider() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1520,7 +1520,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1533,9 +1533,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/fffaff399d20a56d40b9562fa19701e91abd72d8c9d9bc8c2673077b56b6/langchain_core-1.4.7.tar.gz", hash = "sha256:7a825d77de0a3f39adbd9d09612a75e85527e14a52c1601089bcc062972d9f2b", size = 952522, upload-time = "2026-06-12T19:23:57.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3e/dcdffa60078ae7b3a00ebb4cbbf1a204a14c3609983c604886523a7d4418/langchain_core-1.4.7-py3-none-any.whl", hash = "sha256:bcadd51951140ecdcba98311dbd931ba5de02a5ba8a2288dad5069c1eea2a13d", size = 554941, upload-time = "2026-06-12T19:23:55.826Z" },
 ]
 
 [[package]]
@@ -1600,7 +1600,7 @@ typing = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5,<49.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
-    { name = "langchain-core", specifier = ">=1.2.21,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.4.7,<2.0.0" },
     { name = "litellm", specifier = "!=1.82.7,!=1.82.8,>=1.83.14,<2.0.0" },
 ]
 


### PR DESCRIPTION
Chat model instances now report the installed `langchain-litellm` package version through LangChain metadata. The package version is centralized so runtime metadata and release automation use the same source of truth.

## Changes
- Added package version tracking via `ChatLiteLLM._set_litellm_version`, which calls `_add_version("langchain-litellm", __version__)` during model validation.
- Applied the same metadata behavior to `ChatLiteLLMRouter` through its existing `ChatLiteLLM` inheritance path.
- Centralized `__version__` in `langchain_litellm._version` and re-exported it from the package root.
- Registered the version source with release-please so automated releases update both project metadata and runtime version metadata.
- Raised the `langchain-core` lower bound to a version that supports the metadata version API used by the integration.