### PR TITLE
ci(release): gate PyPI publish via environment instead of draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
 name: Release
+
 on:
   push:
     branches:
       - main
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Last-resort escape hatch only. Enter the tag to publish to PyPI manually (e.g. langchain-litellm-v0.x.x) or leave empty to skip. Use only if release:published trigger failed."
+        description: "Last-resort manual publish. Enter the tag to publish (e.g. langchain-litellm==0.x.x) or leave empty to skip. Still requires approval on the pypi environment."
         required: false
 
 permissions:
@@ -17,7 +16,7 @@ permissions:
 
 jobs:
   release-please:
-    # Only runs on push to main; release and workflow_dispatch events skip this job
+    # Only runs on push to main; workflow_dispatch skips this job.
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -25,6 +24,7 @@ jobs:
       pull-requests: write
     outputs:
       pr: ${{ steps.release.outputs.pr }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
@@ -63,13 +63,20 @@ jobs:
           fi
 
   pypi-publish:
-    # Runs in two cases:
-    # 1. A draft GitHub Release is reviewed and published in the UI (release: published flow)
-    # 2. Last-resort escape hatch via workflow_dispatch with a tag input
-    # No always() needed — this job is fully decoupled from release-please.
+    # Publishes to PyPI in two situations, both gated by the `pypi`
+    # environment (its required reviewers are the human approval step):
+    #   1. release-please cut a release on push to main (releases_created == true).
+    #      The matching tag/commit already exists on main at this point.
+    #   2. Last-resort manual publish via workflow_dispatch with a tag input.
+    # Any one listed reviewer can approve, so the team is never blocked on a
+    # single person.
+    needs: release-please
     if: |
-      github.event_name == 'release' ||
-      (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+      always() &&
+      (
+        needs.release-please.outputs.releases_created == 'true' ||
+        (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+      )
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -82,7 +89,7 @@ jobs:
           ref: >-
             ${{
               github.event_name == 'workflow_dispatch' && inputs.tag ||
-              github.ref
+              github.sha
             }}
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
       "component": "langchain-litellm",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "draft": true,
       "extra-files": [
         "pyproject.toml",
         "langchain_litellm/_version.py"


### PR DESCRIPTION
## What

Replace the draft-GitHub-Release publish gate with an approval gate on the
`pypi` deployment environment. release-please now creates a normal (non-draft)
Release and tag when the release PR merges, and PyPI publishing runs as a job in
the same workflow run, held by the environment's required reviewers until a
maintainer approves it.

## Why

With a draft Release, GitHub does not create the Git tag until the release is
published. In the same run that cut the draft, release-please went on to build
the next release PR, could not resolve a tag for the just-cut version, failed to
anchor, walked the full commit history, and opened a spurious minor-bump PR that
re-listed every previously shipped feature. Publishing the release as non-draft
creates the tag at merge time, so the next-PR build anchors correctly and no
stray PR is produced.

Separately, this makes the human checkpoint explicit: a plain PR merge should not
be able to push to immutable PyPI on its own. The environment gate requires a
reviewer to approve before any upload.

## Changes

- Remove `draft: true` from release-please-config.json (non-draft is the default).
- release.yml: drop the `release: published` trigger. Publish from a pypi-publish
  job that runs when release-please reports releases_created, gated by the `pypi`
  environment. Keep the workflow_dispatch tag escape hatch, also gated.

## Operational note

The `pypi` environment must list the maintainer team (or the maintainers) as
required reviewers. Only one needs to approve, so any maintainer can ship a
release independently.

## Verification

- make format, make lint, make test pass.
- On the next release, confirm the publish job waits for approval and that no
  release PR is left open afterward.